### PR TITLE
support formatByStandard by standard fix option

### DIFF
--- a/lib/formatter.js
+++ b/lib/formatter.js
@@ -2,7 +2,7 @@ const path = require("path")
 const fs = require("fs-plus")
 const readPgkUp = require("read-pkg-up")
 const {BufferedProcess} = require("atom")
-let NODE_PREFIX
+let NODE_PREFIX, standard
 
 function getConfig(param) {
   return atom.config.get(`mprettier.${param}`)
@@ -86,9 +86,20 @@ function getNodePrefixPath() {
   return exitPromise
 }
 
+function formatByStandard(text) {
+  if (!standard) standard = require("standard")
+  return standard.lintTextSync(text, {fix: true}).results[0].output
+}
+
 function withFormat(prettier, text, options, fn) {
   try {
-    const newText = prettier.format(text, options)
+    const {spaceBeforeFunctionParen} = options
+    delete options.spaceBeforeFunctionParen
+
+    let newText = prettier.format(text, options)
+    if (spaceBeforeFunctionParen && options.parser === getConfig("scopesForParser").javascriptParser) {
+      newText = formatByStandard(newText)
+    }
     if (newText !== text) fn(newText)
   } catch (error) {
     const notificationMethod = getConfig("notificationMethodOnPrettierError")

--- a/lib/formatter.js
+++ b/lib/formatter.js
@@ -19,8 +19,8 @@ function hasClosestPackageJsonHasPackage(cwd, name) {
   return (dependencies && name in dependencies) || (devDependencies && name in devDependencies)
 }
 
-function prettierIsProjectDependencies(editor) {
-  return hasClosestPackageJsonHasPackage(path.dirname(editor.getPath()), "prettier")
+function isInProjectDependencies(editor, packageName) {
+  return hasClosestPackageJsonHasPackage(path.dirname(editor.getPath()), packageName)
 }
 
 async function findPrettier(editor) {
@@ -86,20 +86,18 @@ function getNodePrefixPath() {
   return exitPromise
 }
 
-function formatByStandard(text) {
-  if (!standard) standard = require("standard")
-  return standard.lintTextSync(text, {fix: true}).results[0].output
-}
-
-function withFormat(prettier, text, options, fn) {
+function withFormat(prettier, text, options, formatByStandard, fn) {
   try {
-    const {spaceBeforeFunctionParen} = options
-    delete options.spaceBeforeFunctionParen
-
     let newText = prettier.format(text, options)
-    if (spaceBeforeFunctionParen && options.parser === getConfig("scopesForParser").javascriptParser) {
-      newText = formatByStandard(newText)
+
+    if (formatByStandard) {
+      if (!standard) standard = require("standard")
+      const result = standard.lintTextSync(text, {fix: true})
+      if (result.results[0].output) {
+        newText = result.results[0].output
+      }
     }
+
     if (newText !== text) fn(newText)
   } catch (error) {
     const notificationMethod = getConfig("notificationMethodOnPrettierError")
@@ -150,19 +148,20 @@ class Formatter {
     return this.constructor.isDisabledFile(filePath)
   }
 
+  skipFormat(editor) {
+    return (
+      !getConfig("formatOnSave.enable") ||
+      this.isDisabledFile(editor.getPath()) ||
+      (getConfig("formatOnSave.skipWhenPrettierIsNotProjectDependencies") &&
+        !isInProjectDependencies(editor, "prettier"))
+    )
+  }
+
   async format(onSave) {
     const editor = this.editor
     const filePath = editor.getPath()
 
-    if (onSave) {
-      if (
-        !getConfig("formatOnSave.enable") ||
-        this.isDisabledFile(editor.getPath()) ||
-        (getConfig("formatOnSave.skipWhenPrettierIsNotProjectDependencies") && !prettierIsProjectDependencies(editor))
-      ) {
-        return
-      }
-    }
+    if (onSave && this.skipFormat(editor)) return
 
     const {prettier, which} = await findPrettier(editor)
     if (!prettier) {
@@ -189,17 +188,30 @@ class Formatter {
     }
 
     const selection = editor.getLastSelection()
+    const formatByStandard = this.needFormatByStarndard(prettierOptions)
     if (!selection.isEmpty()) {
-      withFormat(prettier, selection.getText(), prettierOptions, text => {
+      withFormat(prettier, selection.getText(), prettierOptions, formatByStandard, text => {
         selection.insertText(text)
       })
     } else {
       const point = editor.getCursorBufferPosition()
-      withFormat(prettier, editor.getText(), prettierOptions, text => {
+      withFormat(prettier, editor.getText(), prettierOptions, formatByStandard, text => {
         editor.setText(text)
         editor.setCursorBufferPosition(point)
       })
     }
+  }
+
+  needFormatByStarndard(options) {
+    if (options.parser !== getConfig("scopesForParser").javascriptParser) {
+      return false
+    }
+
+    return (
+      getConfig("formatByStandardForJavascript") ||
+      (getConfig("formatOnSave.formatByStandardForJavascriptIfStandardIsProjectDependencies") &&
+        isInProjectDependencies(this.editor, "standard"))
+    )
   }
 
   buildDebuggInfo({prettier, libPath, which, prettierOptions}) {

--- a/package.json
+++ b/package.json
@@ -188,6 +188,7 @@
   "dependencies": {
     "fs-plus": "^3.0.1",
     "prettier": "^1.8.2",
-    "read-pkg-up": "^3.0.0"
+    "read-pkg-up": "^3.0.0",
+    "standard": "^10.0.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -21,8 +21,13 @@
       "type": "boolean",
       "default": false
     },
-    "formatOnSave": {
+    "formatByStandardForJavascript": {
       "order": 2,
+      "type": "boolean",
+      "default": false
+    },
+    "formatOnSave": {
+      "order": 3,
       "type": "object",
       "collapsed": false,
       "properties": {
@@ -54,11 +59,17 @@
           "items": {
             "type": "string"
           }
+        },
+        "formatByStandardForJavascriptIfStandardIsProjectDependencies": {
+          "title": "Format By Standard For Javascript If Standard Is Project Dependencies",
+          "order": 4,
+          "type": "boolean",
+          "default": true
         }
       }
     },
     "prettierToUseInOrder": {
-      "order": 3,
+      "order": 4,
       "type": "object",
       "collapsed": false,
       "properties": {
@@ -101,7 +112,7 @@
       }
     },
     "scopesForParser": {
-      "order": 4,
+      "order": 5,
       "type": "object",
       "collapsed": false,
       "properties": {


### PR DESCRIPTION
prettier doesn't seem to support `space-before-function-paren`.

https://github.com/prettier/prettier/issues/1139#issuecomment-294503338

I want this feature, but I don't want to use forked prettier.

This PR adds a capability to format by [standard](https://standardjs.com/) with following configuration.
  - `formatByStandardForJavascript`: globally enable format by standard( default `false` )
  - `formatByStandardForJavascriptIfStandardIsProjectDependencies`: Auto enable format-by-standard if `standard` is in project dependencies( default `true` )

standard is processed after `prettier` format.

Refs:
  - https://github.com/dtinth/prettier-standard-formatter
  - https://github.com/arijs/prettier-miscellaneous/pull/22
