### PR TITLE
Default prettier options to object if not found

### DIFF
--- a/lib/formatter.js
+++ b/lib/formatter.js
@@ -177,7 +177,7 @@ class Formatter {
     }
     prettier.clearConfigCache()
     const resolvedPrettierConfig = prettier.resolveConfig.sync(editor.getPath())
-    const prettierOptions = resolvedPrettierConfig || getConfig('prettierOptions')
+    const prettierOptions = resolvedPrettierConfig || getConfig('prettierOptions') || {}
     Object.assign(prettierOptions, {parser: detectParser(editor)})
     const parser = prettierOptions.parser
 


### PR DESCRIPTION
Both `getConfig('prettierOptions')` and  `resolvedPrettierConfig` are null or undefined. This results in an error when attempting to perform ` Object.assign(prettierOptions, {parser: detectParser(editor)})`. Defaulting `prettierOptions` to an Object if both values are falsey will no longer throw an error.

This only errors when trying to format and save with no config or prettier found in dependencies. 